### PR TITLE
Feature/Add proper tailwindcss purge paths

### DIFF
--- a/lottamoberg.com/tailwind.config.js
+++ b/lottamoberg.com/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  purge: [],
+  purge: [
+    './pages/*.@(js|jsx|ts|tsx)',
+    './pages/**/*.@(js|jsx|ts|tsx',
+    './components/**/*.@(js|jsx|ts|tsx)',
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},


### PR DESCRIPTION
For whatever reason the tailwindcss purge paths in `tailwind.config.js` weren't set, though they are for our other sites 🤷 

This PR adds those back in for the `pages` and `components` directories. 

:sparkles: :fire: add tailwind purge paths for smaller deployments